### PR TITLE
Feature/snap type

### DIFF
--- a/lib/android/src/main/java/com/wix/interactable/Events.java
+++ b/lib/android/src/main/java/com/wix/interactable/Events.java
@@ -16,11 +16,12 @@ public class Events {
 
         WritableMap eventData;
 
-        public OnSnapEvent(int viewTag, int indexOfSnapPoint, String snapPointId) {
+        public OnSnapEvent(int viewTag, int indexOfSnapPoint, String snapPointId, String type) {
             super(viewTag);
             eventData = Arguments.createMap();
             eventData.putInt("index",indexOfSnapPoint);
             eventData.putString("id", snapPointId);
+            eventData.putString("type", type);
         }
 
         @Override
@@ -38,11 +39,12 @@ public class Events {
 
         WritableMap eventData;
 
-        public OnSnapStartEvent(int viewTag, int indexOfSnapPoint, String snapPointId) {
+        public OnSnapStartEvent(int viewTag, int indexOfSnapPoint, String snapPointId, String type) {
             super(viewTag);
             eventData = Arguments.createMap();
             eventData.putInt("index",indexOfSnapPoint);
             eventData.putString("id", snapPointId);
+            eventData.putString("type", type);
         }
 
         @Override

--- a/lib/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -320,16 +320,16 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
         }
         this.dragBehavior = null;
 
-        addTempSnapToPointBehavior(snapPoint);
+        addTempSnapToPointBehavior(snapPoint, "endOfDrag");
         addTempBounceBehaviorWithBoundaries(this.boundaries);
     }
 
-    private void addTempSnapToPointBehavior(InteractablePoint snapPoint) {
+    private void addTempSnapToPointBehavior(InteractablePoint snapPoint, String type) {
         if (snapPoint == null) {
             return;
         }
-        listener.onSnap(snapPoints.indexOf(snapPoint), snapPoint.id);
-        listener.onSnapStart(snapPoints.indexOf(snapPoint), snapPoint.id);
+        listener.onSnap(snapPoints.indexOf(snapPoint), snapPoint.id, type);
+        listener.onSnapStart(snapPoints.indexOf(snapPoint), snapPoint.id, type);
         PhysicsSpringBehavior snapBehavior = new PhysicsSpringBehavior(this,snapPoint.positionWithOrigin());
         snapBehavior.tension = snapPoint.tension;
 
@@ -542,7 +542,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
             this.animator.removeTempBehaviors();
             this.dragBehavior = null;
             InteractablePoint snapPoint = snapPoints.get(index);
-            addTempSnapToPointBehavior(snapPoint);
+            addTempSnapToPointBehavior(snapPoint, "snapTo");
             addTempBounceBehaviorWithBoundaries(this.boundaries);
         }
     }
@@ -556,8 +556,8 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
 
 
     public interface InteractionListener {
-        void onSnap(int indexOfSnapPoint, String snapPointId);
-        void onSnapStart(int indexOfSnapPoint, String snapPointId);
+        void onSnap(int indexOfSnapPoint, String snapPointId, String type);
+        void onSnapStart(int indexOfSnapPoint, String snapPointId, String type);
         void onAlert(String alertAreaId, String alertType);
         void onAnimatedEvent(float x, float y);
         void onDrag(String state, float x, float y, String targetSnapPointId);

--- a/lib/android/src/main/java/com/wix/interactable/InteractableViewManager.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableViewManager.java
@@ -176,13 +176,13 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
         }
 
         @Override
-        public void onSnap(int indexOfSnapPoint, String snapPointId) {
-            eventDispatcher.dispatchEvent(new Events.OnSnapEvent(interactableView.getId(), indexOfSnapPoint, snapPointId));
+        public void onSnap(int indexOfSnapPoint, String snapPointId, String type) {
+            eventDispatcher.dispatchEvent(new Events.OnSnapEvent(interactableView.getId(), indexOfSnapPoint, snapPointId, type));
         }
 
         @Override
-        public void onSnapStart(int indexOfSnapPoint, String snapPointId) {
-            eventDispatcher.dispatchEvent(new Events.OnSnapStartEvent(interactableView.getId(), indexOfSnapPoint, snapPointId));
+        public void onSnapStart(int indexOfSnapPoint, String snapPointId, String type) {
+            eventDispatcher.dispatchEvent(new Events.OnSnapStartEvent(interactableView.getId(), indexOfSnapPoint, snapPointId, type));
         }
 
         @Override

--- a/lib/ios/Interactable/InteractableView.m
+++ b/lib/ios/Interactable/InteractableView.m
@@ -435,7 +435,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
     InteractablePoint *snapPoint = [InteractablePoint findClosestPoint:self.snapPoints toPoint:projectedCenter withOrigin:self.origin];
 
-    self.snapType = "endOfDrag";
+    self.snapType = @"endOfDrag";
 
     if (snapPoint)
     {
@@ -610,7 +610,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     {
         [self.animator removeTempBehaviors];
         self.dragBehavior = nil;
-        self.snapType = "snapTo";
+        self.snapType = @"snapTo";
         
         InteractablePoint *snapPoint = [self.snapPoints objectAtIndex:index];
         if (snapPoint) {

--- a/lib/ios/Interactable/InteractableView.m
+++ b/lib/ios/Interactable/InteractableView.m
@@ -96,6 +96,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 @property (nonatomic) NSMutableSet *insideAlertAreas;
 @property (nonatomic) UIPanGestureRecognizer *pan;
 
+@property (nonatomic, assign) uint16_t snapType;
 @property (nonatomic, assign) uint16_t coalescingKey;
 @property (nonatomic, assign) NSString* lastEmittedEventName;
 
@@ -214,7 +215,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
             self.onSnap(@
                         {
                             @"index": @([self.snapPoints indexOfObject:snapPoint]),
-                            @"id": snapPoint.id
+                            @"id": snapPoint.id,
+                            @"type": self.snapType,
                         });
         }
     }
@@ -433,6 +435,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
     InteractablePoint *snapPoint = [InteractablePoint findClosestPoint:self.snapPoints toPoint:projectedCenter withOrigin:self.origin];
 
+    self.snapType = "endOfDrag";
+
     if (snapPoint)
     {
         [self addTempSnapToPointBehavior:snapPoint];
@@ -441,7 +445,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
             self.onSnapStart(@
                         {
                             @"index": @([self.snapPoints indexOfObject:snapPoint]),
-                            @"id": snapPoint.id
+                            @"id": snapPoint.id,
+                            @"type": self.snapType,
                         });
         }
     }
@@ -605,6 +610,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     {
         [self.animator removeTempBehaviors];
         self.dragBehavior = nil;
+        self.snapType = "snapTo";
         
         InteractablePoint *snapPoint = [self.snapPoints objectAtIndex:index];
         if (snapPoint) {
@@ -613,7 +619,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                 self.onSnapStart(@
                             {
                                 @"index": @([self.snapPoints indexOfObject:snapPoint]),
-                                @"id": snapPoint.id
+                                @"id": snapPoint.id,
+                                @"type": self.snapType,
                             });
             }
         }

--- a/lib/ios/Interactable/InteractableView.m
+++ b/lib/ios/Interactable/InteractableView.m
@@ -96,8 +96,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 @property (nonatomic) NSMutableSet *insideAlertAreas;
 @property (nonatomic) UIPanGestureRecognizer *pan;
 
-@property (nonatomic, assign) uint16_t snapType;
 @property (nonatomic, assign) uint16_t coalescingKey;
+@property (nonatomic, assign) NSString* snapType;
 @property (nonatomic, assign) NSString* lastEmittedEventName;
 
 @end

--- a/typings/react-native-interactable.d.ts
+++ b/typings/react-native-interactable.d.ts
@@ -70,6 +70,7 @@ declare module 'react-native-interactable' {
     interface INativeSnapEvent {
       index: number;
       id: string;
+      type: string;
     }
 
     interface ISnapEvent {

--- a/typings/react-native-interactable.d.ts
+++ b/typings/react-native-interactable.d.ts
@@ -70,7 +70,7 @@ declare module 'react-native-interactable' {
     interface INativeSnapEvent {
       index: number;
       id: string;
-      type: string;
+      type: 'endOfDrag' | 'snapTo';
     }
 
     interface ISnapEvent {


### PR DESCRIPTION
This PR adds snap type information to `onSnap` and `onSnapStart` events. The issue was that we were not able to differentiate if a snap start / end is caused by user action, or by calling snapTo method.

INativeSnapEvent is in current shape right now:

    interface INativeSnapEvent {
      index: number;
      id: string;
      type: 'endOfDrag' | 'snapTo';
    }